### PR TITLE
Fix aftman.toml file being removed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,8 @@ runs:
 
     - name: Delete artifacts
       run: |
-        rm aftman*.zip
-        rm aftman*
+        rm -v aftman*.zip
+        rm -v aftman*
       shell: bash
 
     - name: Set environment variable

--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,12 @@ runs:
 
     - name: Delete artifacts
       run: |
-        rm -v aftman*.zip
-        rm -v aftman*
+        rm aftman*.zip
+        if [[ ${{ runner.os == 'Windows' }} ]]; then
+          rm aftman.exe
+        else
+          rm aftman
+        fi
       shell: bash
 
     - name: Set environment variable

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Delete artifacts
       run: |
         rm aftman*.zip
-        if [[ ${{ runner.os == 'Windows' }} ]]; then
+        if ${{ runner.os == 'Windows' }}; then
           rm aftman.exe
         else
           rm aftman


### PR DESCRIPTION
It seems like installation is failing since this commit https://github.com/ok-nick/setup-aftman/commit/3a79d6c063a62d55640f7dbfd9f3af5a5286a54c because `rm aftman*` also removes the `aftman.toml` file that contains the tool definitions. This PR makes the pattern more specific and removes exact filenames `aftman.exe` on Windows and `aftman` on macOS/Linux instead.