### PR TITLE
hash only `aftman.toml` + cache `~/.aftman/tool-storage` + renovate CI

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -10,9 +10,7 @@ on:
         required: false
       cache:
         type: string
-        required: false
-      token:
-        type: string
+        default: "true"
         required: false
 
 jobs:
@@ -40,7 +38,6 @@ jobs:
         version: ${{ inputs.version }}
         path: ${{ inputs.path }}
         cache: ${{ inputs.cache }}
-        token: ${{ inputs.token }}
 
     - name: Verify executables in PATH on bash
       run: |

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -6,12 +6,15 @@ on:
         required: false
       path:
         type: string
+        default: "."
         required: false
       cache:
         type: string
+        default: "true"
         required: false
       token:
         type: string
+        default: "${{ github.token }}"
         required: false
 
 jobs:

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -2,17 +2,17 @@ on:
   workflow_call:
     inputs:
       version:
-        required: false
         type: string
+        required: false
       path:
-        required: false
         type: string
+        required: false
       cache:
-        required: false
         type: string
+        required: false
       token:
-        required: false
         type: string
+        required: false
 
 jobs:
   test-env:

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -1,28 +1,35 @@
-name: Test
-description: Test `setup-aftman`.
-author: ok-nick
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: false
+        type: string
+      path:
+        required: false
+        type: string
+      cache:
+        required: false
+        type: string
+      token:
+        required: false
+        type: string
 
-# same input as `setup-aftman`
-inputs:
-  version:
-    required: false
-  path:
-    default: "."
-    required: false
-  token:
-    default: "${{ github.token }}"
-    required: false
+jobs:
+  test-env:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
 
-runs:
-  using: "composite"
-  steps:
     - name: Create manifest file
       run: |
         cat > ${{ inputs.path }}/aftman.toml << EOF
         [tools]
-        selene = "Kampfkarren/selene@0.19.1"
-        stylua = "JohnnyMorganz/stylua@0.14.0"
-        rojo = "rojo-rbx/rojo@7.2.1"
+        selene = "Kampfkarren/selene@0.25.0"
+        stylua = "JohnnyMorganz/stylua@0.18.2"
+        rojo = "rojo-rbx/rojo@7.3.0"
         EOF
       shell: bash
 
@@ -31,6 +38,7 @@ runs:
       with:
         version: ${{ inputs.version }}
         path: ${{ inputs.path }}
+        cache: ${{ inputs.cache }}
         token: ${{ inputs.token }}
 
     - name: Verify executables in PATH on bash

--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -10,11 +10,9 @@ on:
         required: false
       cache:
         type: string
-        default: "true"
         required: false
       token:
         type: string
-        default: "${{ github.token }}"
         required: false
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ defaults:
 
 jobs:
   test-cache:
-    uses: ./.github/actions/env.yml
+    uses: ./.github/workflows/env.yml
   test-no-cache:
-    uses: ./.github/actions/env.yml
+    uses: ./.github/workflows/env.yml
     with:
       cache: "false"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,53 +13,9 @@ defaults:
     shell: bash
 
 jobs:
-  test_linux:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/test
-
-  test_mac:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/test
-
-  test_windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/test
-
-  test_linux_version_and_path:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - run: mkdir project
-      - uses: ./.github/actions/test
-        with:
-          version: v0.2.7
-          path: "./project"
-
-  test_mac_version_and_path:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - run: mkdir project
-      - uses: ./.github/actions/test
-        with:
-          version: v0.2.7
-          path: "./project"
-
-  test_windows_version_and_path:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - run: mkdir project
-      - uses: ./.github/actions/test
-        with:
-          version: v0.2.7
-          path: "./project"
+  test-cache:
+    uses: ./.github/actions/env.yml
+  test-no-cache:
+    uses: ./.github/actions/env.yml
+    with:
+      cache: "false"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ steps:
   with:
     version: v1.0.0 # name of git tag in aftman (uses latest by default)
     path: some_dir/my_project # path to project dir containing `aftman.toml` (uses current dir by default)
-    cache: true # whether to enable binary caching between runs (true by default)
+    cache: "true" # whether to enable binary caching between runs (true by default)
     token: ${{ github.token }} # GitHub token to bypass rate limit (passed by default)
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,10 @@ runs:
       if: ${{ inputs.cache == 'true' }}
       uses: actions/cache@v3
       with:
-        path: ~/.aftman/bin
+        path: |
+          ~/.aftman/bin
+          ~/.aftman/tool-storage
+        # TODO: also hash ~/.aftman/aftman.toml
         key: ${{ runner.os }}-aftman-${{hashFiles(format('{0}/{1}', inputs.path, 'aftman.toml'))}}
 
     - name: Install tools

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.aftman/bin
-        key: ${{ runner.os }}-aftman-${{hashFiles(inputs.path)}}
+        key: ${{ runner.os }}-aftman-${{hashFiles(format('{0}/{1}', inputs.path, 'aftman.toml'))}}
 
     - name: Install tools
       run: |


### PR DESCRIPTION
In order for caching to work properly, it must cache the `~/.aftman/tool-storage` directory in addition to the `~/.aftman/bin` directory.

Caching should not be dependent on the content of the workspace, but instead only on the content of the `aftman.toml`.

CI needed a renovation, it now includes reusable workflows and matrices. Even better, would be to only abstract the `aftman.toml` creation and testing into separate steps.