### PR TITLE
Disable cache by default & use `$HOME` for env vars

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ defaults:
 jobs:
   test-cache:
     uses: ./.github/workflows/env.yml
+    with:
+      cache: "true"
   test-no-cache:
     uses: ./.github/workflows/env.yml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Disable caching by default #15
+
+## Fixed
+- Issue causing executables to not be found #14
 
 ## [0.4.1] - 2023-09-18
 ## Fixed

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
   cache:
     description: "Whether to enable caching"
-    default: "true"
+    default: "false"
     required: false
   token:
     description: "GitHub token via `github.token`"

--- a/action.yml
+++ b/action.yml
@@ -73,8 +73,8 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          $HOME/.aftman/bin
-          $HOME/.aftman/tool-storage
+          ~/.aftman/bin
+          ~/.aftman/tool-storage
         key: ${{ runner.os }}-aftman-${{hashFiles(format('{0}/{1}', inputs.path, 'aftman.toml'))}}
 
     - name: Install tools

--- a/action.yml
+++ b/action.yml
@@ -58,12 +58,12 @@ runs:
 
     - name: Set environment variable
       if: runner.os != 'Windows'
-      run: echo "~/.aftman/bin" >> $GITHUB_PATH
+      run: echo "$HOME/.aftman/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: Create auth file
       run: |
-        cat > ~/.aftman/auth.toml << EOF
+        cat > $HOME/.aftman/auth.toml << EOF
         github = "${{ inputs.token }}"
         EOF
       shell: bash
@@ -73,9 +73,8 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.aftman/bin
-          ~/.aftman/tool-storage
-        # TODO: also hash ~/.aftman/aftman.toml
+          $HOME/.aftman/bin
+          $HOME/.aftman/tool-storage
         key: ${{ runner.os }}-aftman-${{hashFiles(format('{0}/{1}', inputs.path, 'aftman.toml'))}}
 
     - name: Install tools


### PR DESCRIPTION
Caching saves a few seconds, sometimes, and mostly only on Linux with the 3 tools defined in CI. It's useful if there are a lot of tools or if you hit the GitHub rate limit, otherwise it's extra time and storage.

Using `$HOME` instead of `~` for the path when setting env vars closes #14 