### PR TITLE
Update cache action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
 
     - name: Cache binaries
       if: ${{ inputs.cache == true || inputs.cache == 'true' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.aftman/bin


### PR DESCRIPTION
Updates actions/cache@v3 to actions/cache@v4 in response to GitHub's deprecation of Node.js 16 actions.