### PR TITLE
Add runner architecture detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ steps:
 
 The git tag of `aftman` to install from releases and use. By default this input will be assigned to the latest version of `aftman`.
 
-### `architecture`
-
-The [architecture](https://doc.rust-lang.org/rustc/platform-support.html#tier-1-with-host-tools) of the `aftman` binary to install from the Github release downloads. By default this input will be `x86_64`.
-
 ### `path`
 
 The path to the directory containing the `aftman.toml` to install tools from. The default is the current directory (`.`).

--- a/README.md
+++ b/README.md
@@ -9,45 +9,61 @@
 GitHub action to install and run [aftman](https://github.com/LPGhatguy/aftman); a toolchain manager.
 
 ## Usage
+
 Use the latest released version of `aftman` with default parameters:
+
 ```yaml
 steps:
-- uses: ok-nick/setup-aftman@v0.4.2
+    - uses: ok-nick/setup-aftman@v0.4.2
 ```
+
 For a list of default parameter values, [check here](https://github.com/ok-nick/setup-aftman/blob/main/action.yml#L5-L20).
 
 ### Advanced
+
 For more advanced cases, use the parameters below.
+
 ```yaml
 steps:
-- uses: ok-nick/setup-aftman@v0.4.2
-  with:
-    version: v1.0.0 # name of git tag in aftman (uses latest tag by default)
-    path: some_dir/my_project # path to project dir containing `aftman.toml` ("." (current dir) by default)
-    cache: false # whether to enable binary caching between runs (false by default)
-    token: ${{ github.token }} # GitHub token to bypass rate limit (${{ github.token }} set by default)
+    - uses: ok-nick/setup-aftman@v0.4.2
+      with:
+          version: v1.0.0 # name of git tag in aftman (uses latest tag by default)
+          architecture: x86_64 # architecture of aftman binary to install ("x86_64" by default)
+          path: some_dir/my_project # path to project dir containing `aftman.toml` ("." (current dir) by default)
+          cache: false # whether to enable binary caching between runs (false by default)
+          token: ${{ github.token }} # GitHub token to bypass rate limit (${{ github.token }} set by default)
 ```
 
 ## Inputs
+
 ### `version`
+
 The git tag of `aftman` to install from releases and use. By default this input will be assigned to the latest version of `aftman`.
 
+### `architecture`
+
+The [architecture](https://doc.rust-lang.org/rustc/platform-support.html#tier-1-with-host-tools) of the `aftman` binary to install from the Github release downloads. By default this input will be `x86_64`.
+
 ### `path`
+
 The path to the directory containing the `aftman.toml` to install tools from. The default is the current directory (`.`).
 
 ### `cache`
+
 Enable to cache tools installed by `aftman`, the default value of this input is `false`. Note, in many cases enabling this feature will slow down the `setup-aftman` action.
 
 There are a few reasons you may choose to enable caching:
-* Action runs often, causing the GitHub rate-limit to be reached
-* A large amount of tools to install
-* Server downloading from is slow
+
+-   Action runs often, causing the GitHub rate-limit to be reached
+-   A large amount of tools to install
+-   Server downloading from is slow
 
 In any case, it is recommended to benchmark before enabling this feature.
 
 ### `token`
+
 Set to a GitHub token to be used by `aftman` to increase the GitHub rate-limit. Note, these two options, `${{ github.token }}` and `${{ secrets.GITHUB_TOKEN }}`, are equivalent and passed by default. **Thus, you do not need to specify this parameter unless you are using a token different from the owner of the repository.**
 
 ## Credits
-[@nezuo](https://github.com/nezuo) - Installing `aftman` using `gh`
 
+[@nezuo](https://github.com/nezuo) - Installing `aftman` using `gh`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ steps:
     - uses: ok-nick/setup-aftman@v0.4.2
       with:
           version: v1.0.0 # name of git tag in aftman (uses latest tag by default)
-          architecture: x86_64 # architecture of aftman binary to install ("x86_64" by default)
           path: some_dir/my_project # path to project dir containing `aftman.toml` ("." (current dir) by default)
           cache: false # whether to enable binary caching between runs (false by default)
           token: ${{ github.token }} # GitHub token to bypass rate limit (${{ github.token }} set by default)

--- a/README.md
+++ b/README.md
@@ -9,56 +9,45 @@
 GitHub action to install and run [aftman](https://github.com/LPGhatguy/aftman); a toolchain manager.
 
 ## Usage
-
 Use the latest released version of `aftman` with default parameters:
-
 ```yaml
 steps:
-    - uses: ok-nick/setup-aftman@v0.4.2
+- uses: ok-nick/setup-aftman@v0.4.2
 ```
-
 For a list of default parameter values, [check here](https://github.com/ok-nick/setup-aftman/blob/main/action.yml#L5-L20).
 
 ### Advanced
-
 For more advanced cases, use the parameters below.
-
 ```yaml
 steps:
-    - uses: ok-nick/setup-aftman@v0.4.2
-      with:
-          version: v1.0.0 # name of git tag in aftman (uses latest tag by default)
-          path: some_dir/my_project # path to project dir containing `aftman.toml` ("." (current dir) by default)
-          cache: false # whether to enable binary caching between runs (false by default)
-          token: ${{ github.token }} # GitHub token to bypass rate limit (${{ github.token }} set by default)
+- uses: ok-nick/setup-aftman@v0.4.2
+  with:
+    version: v1.0.0 # name of git tag in aftman (uses latest tag by default)
+    path: some_dir/my_project # path to project dir containing `aftman.toml` ("." (current dir) by default)
+    cache: false # whether to enable binary caching between runs (false by default)
+    token: ${{ github.token }} # GitHub token to bypass rate limit (${{ github.token }} set by default)
 ```
 
 ## Inputs
-
 ### `version`
-
 The git tag of `aftman` to install from releases and use. By default this input will be assigned to the latest version of `aftman`.
 
 ### `path`
-
 The path to the directory containing the `aftman.toml` to install tools from. The default is the current directory (`.`).
 
 ### `cache`
-
 Enable to cache tools installed by `aftman`, the default value of this input is `false`. Note, in many cases enabling this feature will slow down the `setup-aftman` action.
 
 There are a few reasons you may choose to enable caching:
-
--   Action runs often, causing the GitHub rate-limit to be reached
--   A large amount of tools to install
--   Server downloading from is slow
+* Action runs often, causing the GitHub rate-limit to be reached
+* A large amount of tools to install
+* Server downloading from is slow
 
 In any case, it is recommended to benchmark before enabling this feature.
 
 ### `token`
-
 Set to a GitHub token to be used by `aftman` to increase the GitHub rate-limit. Note, these two options, `${{ github.token }}` and `${{ secrets.GITHUB_TOKEN }}`, are equivalent and passed by default. **Thus, you do not need to specify this parameter unless you are using a token different from the owner of the repository.**
 
 ## Credits
-
 [@nezuo](https://github.com/nezuo) - Installing `aftman` using `gh`
+

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
   version:
     description: "`aftman` git tag (usually in the form vx.x.x)"
     required: false
+  architecture:
+    description: "architecture of the system you're installing for. currently can be x86_64 or aarch64 (arm64)."
+    default: "x86_64"
+    required: false
   path:
     description: "Path to the `aftman.toml` directory"
     default: "."
@@ -25,9 +29,9 @@ runs:
     - name: Download aftman
       run: |
         case ${{ runner.os }} in
-          Linux) pattern="*linux-x86_64.zip" ;;
-          macOS) pattern="*macos-x86_64.zip" ;;
-          Windows) pattern="*windows-x86_64.zip" ;;
+          Linux) pattern="*linux-${{ inputs.architecture }}.zip" ;;
+          macOS) pattern="*macos-${{ inputs.architecture }}.zip" ;;
+          Windows) pattern="*windows-${{ inputs.architecture }}.zip" ;;
         esac
 
         gh release download ${{ inputs.version }} --repo LPGhatguy/aftman --pattern $pattern

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: "`aftman` git tag (usually in the form vx.x.x)"
     required: false
   architecture:
-    description: "architecture of the system you're installing for. currently can be x86_64 or aarch64 (arm64)."
+    description: "architecture of the system you're installing for"
     default: "x86_64"
     required: false
   path:

--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,6 @@ inputs:
   version:
     description: "`aftman` git tag (usually in the form vx.x.x)"
     required: false
-  architecture:
-    description: "architecture of the system you're installing for"
-    default: "x86_64"
-    required: false
   path:
     description: "Path to the `aftman.toml` directory"
     default: "."
@@ -28,10 +24,15 @@ runs:
   steps:
     - name: Download aftman
       run: |
+        case ${{ runner.arch }} in
+          "X86" | "X64") fileArch="x86_64" ;;
+          "ARM" | "ARM64") fileArch="aarch64" ;;
+        esac
+
         case ${{ runner.os }} in
-          Linux) pattern="*linux-${{ inputs.architecture }}.zip" ;;
-          macOS) pattern="*macos-${{ inputs.architecture }}.zip" ;;
-          Windows) pattern="*windows-${{ inputs.architecture }}.zip" ;;
+          Linux) pattern="*linux-$fileArch.zip" ;;
+          macOS) pattern="*macos-$fileArch.zip" ;;
+          Windows) pattern="*windows-$fileArch.zip" ;;
         esac
 
         gh release download ${{ inputs.version }} --repo LPGhatguy/aftman --pattern $pattern


### PR DESCRIPTION
## Proposed changes

This pull adds support for runner architecture detection so Aftman can be installed from the correct release artifact.